### PR TITLE
ZCS-4465

### DIFF
--- a/default-template/debian/control.in
+++ b/default-template/debian/control.in
@@ -13,6 +13,6 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, @@PKG_DEPENDS@@
 Pre-Depends: @@PKG_PRE_DEPENDS@@
 Provides: @@PKG_PROVIDES@@
-Conflicts: @@PKG_CONFLICTS@@
-Replaces: @@PKG_REPLACES@@
+Conflicts: @@PKG_CONFLICTS@@, @@PKG_OBSOLETES@@
+Replaces: @@PKG_REPLACES@@, @@PKG_OBSOLETES@@
 Description: @@PKG_SUMMARY@@

--- a/default-template/rpm/1.spec.in
+++ b/default-template/rpm/1.spec.in
@@ -11,7 +11,7 @@ AutoReqProv: no
 Requires: @@PKG_DEPENDS@@
 PreReq: @@PKG_PRE_DEPENDS@@
 Provides: @@PKG_PROVIDES@@
-Obsoletes: @@PKG_REPLACES@@
+Obsoletes: @@PKG_OBSOLETES@@
 Conflicts: @@PKG_CONFLICTS@@
 
 %description

--- a/pkg-build.pl
+++ b/pkg-build.pl
@@ -384,6 +384,13 @@ sub Init()
          default_sub  => sub { return []; },
       },
       {
+         name         => "PKG_OBSOLETES",
+         type         => "=s@",
+         hash_src     => \%cmd_hash,
+         validate_sub => undef,
+         default_sub  => sub { return []; },
+      },
+      {
          name         => "PKG_REPLACES",
          type         => "=s@",
          hash_src     => \%cmd_hash,
@@ -589,6 +596,7 @@ sub Build()
                   $line =~ s/[@][@]PKG_PRE_DEPENDS[@][@]/@{[_SanitizePkgList($CFG{PKG_PRE_DEPENDS})]}/g;
                   $line =~ s/[@][@]PKG_PROVIDES[@][@]/@{[_SanitizePkgList($CFG{PKG_PROVIDES})]}/g;
                   $line =~ s/[@][@]PKG_CONFLICTS[@][@]/@{[_SanitizePkgList($CFG{PKG_CONFLICTS})]}/g;
+                  $line =~ s/[@][@]PKG_OBSOLETES[@][@]/@{[_SanitizePkgList($CFG{PKG_OBSOLETES})]}/g;
                   $line =~ s/[@][@]PKG_REPLACES[@][@]/@{[_SanitizePkgList($CFG{PKG_REPLACES})]}/g;
 
                   if ( $line =~ m/^\s*[A-Za-z][A-Za-z_0-9-]*\s*[:](\s*,*\s*)*$/ )    # drop lines with empty headers


### PR DESCRIPTION
- Introduce obsoletes tag back so in rpm we will be able to use it to remove packages